### PR TITLE
Uncomment language in properties until code changes can be implemented

### DIFF
--- a/config/configure.properties.example
+++ b/config/configure.properties.example
@@ -15,7 +15,7 @@ skillset=
 #tenantID=
 
 # Client language specific preferences can be passed (Optional parameter with a default value: en-US)
-#language=en-US
+language=en-US
 
 # Choosing which STT and TTS engine to convert audio to text and text to audio - possible values are : watson, google , (Optional parameter with a default value : watson)
 #engine=


### PR DESCRIPTION
The audio client is not sending a language value to the server if one isn't specified in the properties file and the server does not respond correctly if it doesn't receive a language value in the request.

As a quick fix, this change is uncommenting the language property.  A separate change will be submitted for the code to provide the default language value (en-US) in the requests if the property doesn't exist.